### PR TITLE
Adding Retain=True to HASS discovery message

### DIFF
--- a/inkbird/hass.py
+++ b/inkbird/hass.py
@@ -15,7 +15,7 @@ class Sensor:
         self.discover()
 
     def discover(self):
-        mqtt.publish(self.discovery_topic(), json.dumps(self.discovery_message))
+        mqtt.publish(self.discovery_topic(), json.dumps(self.discovery_message), True)
 
     def update(self):
         mqtt.publish(self.publish_topic(), self.message)

--- a/inkbird/mqtt.py
+++ b/inkbird/mqtt.py
@@ -26,10 +26,10 @@ class MqttController:
 
         self.client = client
 
-    def publish(self, topic, message, retain=False):
+    def publish(self, topic, message, retainMessage=False):
         if not self.client.is_connected():
             self.setup()
-        self.client.publish(topic, message, retain=retain)
+        self.client.publish(topic, message, retain=retainMessage)
 
 
 client = MqttController()

--- a/inkbird/mqtt.py
+++ b/inkbird/mqtt.py
@@ -26,10 +26,10 @@ class MqttController:
 
         self.client = client
 
-    def publish(self, topic, message):
+    def publish(self, topic, message, retain=False):
         if not self.client.is_connected():
             self.setup()
-        self.client.publish(topic, message)
+        self.client.publish(topic, message, retain=retain)
 
 
 client = MqttController()

--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ logger = logging.getLogger("inkbird")
 logger.setLevel(logging.INFO)
 
 logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s %(name)-12s %(levelname)-8s %(message)s"
+    level=logging.INFO, format="%(asctime)s %(name)-15s %(levelname)-8s %(message)s"
 )
 
 MAX_BACKOFF = 60


### PR DESCRIPTION
I was finding that after a restart of Home Assistant, the auto-discovered MQTT sensors were no longer available and/or updating.

Adding `retain=True` to the discovery message means that Home Assistant will always know how to work with the auto-discovered sensors.

Also added more spacing to logging.